### PR TITLE
Expose CallClient via public getter in DailyTransport

### DIFF
--- a/Sources/PipecatClientIOSDaily/DailyTransport.swift
+++ b/Sources/PipecatClientIOSDaily/DailyTransport.swift
@@ -5,6 +5,10 @@ import Daily
 /// An RTVI transport to connect with Daily.
 public class DailyTransport: Transport {
     private var callClient: CallClient?
+    /// Expose the underlying Daily CallClient for direct SDK interaction (e.g. zoom, torch).
+    public var dailyCallClient: CallClient? {
+        return self.callClient
+    }
     private var voiceClientOptions: PipecatClientIOS.RTVIClientOptions
 
     private var devicesInitialized: Bool = false


### PR DESCRIPTION
This change adds a single public property to DailyTransport that exposes its internal CallClient instance. By doing so, consumers of the transport can directly invoke Daily SDK methods—such as camera zoom and torch control—without needing to duplicate or re‐implement the underlying client logic.

What was added:

public var dailyCallClient: CallClient? { return self.callClient } immediately after the private callClient declaration.

Why:

The Daily iOS SDK’s built-in methods (setCameraZoom, setCameraTorch, etc.) aren’t otherwise accessible through the Transport interface.

Exposing callClient allows app-level code to use Daily’s full camera control surface while still retaining all of the existing transport behaviors.