### PR TITLE
Preparing for the 0.3.6 release

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/pipecat-ai/pipecat-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "c679512e367002a1a67da85d503fec72d9b17191",
-          "version": "0.3.2"
+          "revision": "f92b5e68e56a8311f7d8ead68a7a5674843cbc40",
+          "version": "0.3.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Local dependency
         //.package(path: "../pipecat-client-ios"),
-        .package(url: "https://github.com/pipecat-ai/pipecat-client-ios.git", from: "0.3.2"),
+        .package(url: "https://github.com/pipecat-ai/pipecat-client-ios.git", from: "0.3.6"),
         .package(url: "https://github.com/daily-co/daily-client-ios.git", from: "0.23.0")
     ],
     targets: [

--- a/PipecatClientIOSDaily.podspec
+++ b/PipecatClientIOSDaily.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'PipecatClientIOSDaily'
-  s.version      = '0.3.2'
+  s.version      = '0.3.6'
   s.summary      = 'Pipecat iOS client library with Daily WebRTC transport.'
   s.description  = <<-DESC
                     The Daily transport implementation enables real-time audio and video communication in your Pipecat iOS applications using Daily’s WebRTC infrastructure.
@@ -9,12 +9,12 @@ Pod::Spec.new do |s|
   s.documentation_url  = "https://docs.pipecat.ai/client/ios/introduction"
   s.license      = { :type => 'BSD-2', :file => 'LICENSE' }
   s.author             = { "Daily.co" => "help@daily.co" }
-  s.source       = { :git => 'https://github.com/pipecat-ai/pipecat-client-ios-daily.git', :tag => "0.3.2" }
+  s.source       = { :git => 'https://github.com/pipecat-ai/pipecat-client-ios-daily.git', :tag => "0.3.6" }
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/**/*.{swift,h,m}'
   s.exclude_files = 'Sources/Exclude'
   s.swift_version = '5.5'
   # Dependencies
-  s.dependency 'PipecatClientIOS', '~> 0.3.2'
+  s.dependency 'PipecatClientIOS', '~> 0.3.6'
   s.dependency 'Daily', '~> 0.23.0'
 end


### PR DESCRIPTION
Bumping PipecatClientIOSDaily to use the latest version of PipecatClientIOS and preparing for the 0.3.6 release